### PR TITLE
Add return for functions

### DIFF
--- a/esp8266_robot/esp8266_robot.ino
+++ b/esp8266_robot/esp8266_robot.ino
@@ -90,8 +90,8 @@ int stop(String command) {
  
   R_MOTOR->setSpeed(0);
   R_MOTOR->run( RELEASE );
+
   return 1;
-  
 }
 
 int forward(String command) {
@@ -102,8 +102,8 @@ int forward(String command) {
  
   R_MOTOR->setSpeed(200);
   R_MOTOR->run( FORWARD );
+
   return 1;
-  
 }
 
 int left(String command) {
@@ -114,8 +114,8 @@ int left(String command) {
  
   R_MOTOR->setSpeed(100);
   R_MOTOR->run( FORWARD );
-  return 1;
 
+  return 1;
 }
 
 int right(String command) {
@@ -126,8 +126,8 @@ int right(String command) {
  
   R_MOTOR->setSpeed(100);
   R_MOTOR->run( BACKWARD );
+
   return 1;
-  
 }
 
 int backward(String command) {
@@ -138,6 +138,6 @@ int backward(String command) {
  
   R_MOTOR->setSpeed(150);
   R_MOTOR->run( BACKWARD );
-  return 1;
   
+  return 1;
 }

--- a/esp8266_robot/esp8266_robot.ino
+++ b/esp8266_robot/esp8266_robot.ino
@@ -90,6 +90,7 @@ int stop(String command) {
  
   R_MOTOR->setSpeed(0);
   R_MOTOR->run( RELEASE );
+  return 1;
   
 }
 
@@ -101,6 +102,7 @@ int forward(String command) {
  
   R_MOTOR->setSpeed(200);
   R_MOTOR->run( FORWARD );
+  return 1;
   
 }
 
@@ -112,7 +114,8 @@ int left(String command) {
  
   R_MOTOR->setSpeed(100);
   R_MOTOR->run( FORWARD );
-  
+  return 1;
+
 }
 
 int right(String command) {
@@ -123,6 +126,7 @@ int right(String command) {
  
   R_MOTOR->setSpeed(100);
   R_MOTOR->run( BACKWARD );
+  return 1;
   
 }
 
@@ -134,5 +138,6 @@ int backward(String command) {
  
   R_MOTOR->setSpeed(150);
   R_MOTOR->run( BACKWARD );
+  return 1;
   
 }


### PR DESCRIPTION
Currently, some esp8266 robots crash without any return as the return type is `int`.
aREST seems to expect an `int` return type for functions, so returning `1` should be fine.